### PR TITLE
MongoClient() updates, lock race fix, write concern support

### DIFF
--- a/MongoSession.php
+++ b/MongoSession.php
@@ -239,13 +239,15 @@ class MongoSession
      */
     public function dbInit()
     {
-        $this->sessions->ensureIndex(array(
-            'last_accessed' => 1
-        ));
-
-        $this->locks->ensureIndex(array(
-            'created' => 1
-        ));
+      $mongo_index = ( (phpversion('mongo') >= '1.5.0') ? ('createIndex') : ('ensureIndex') );
+      $this->log("maint: {$mongo_index} on ".$this->getConfig('collection')); 
+      $this->sessions->$mongo_index(array(
+					  'last_accessed' => 1
+					  ));
+      $this->log("maint: {$mongo_index} on ".$this->getConfig('lockcollection'));
+      $this->locks->$mongo_index(array(
+				       'created' => 1
+				       ));
     }
 
     /**

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -47,7 +47,7 @@ class MongoSession
     private static $config = array(
         'name'              => 'PHPSESSID',
         'connection'        => 'mongodb://localhost:27017',
-	'connection_opts'   => array(),//options to pass to MongoClient
+        'connection_opts'   => array(),//options to pass to MongoClient
         'db'                => 'mySessDb',
         'collection'        => 'sessions',
         'lockcollection'    => 'sessions_lock',
@@ -64,8 +64,8 @@ class MongoSession
         'error_handler'     => 'trigger_error',
         'logger'            => false,//by default, no logging
         'machine_id'        => false,//identify the machine, if you want for debugs
-	'write_concern'     => 1,//by default, MongoClient uses w=1 (Mongo 'safe' mode)
-	'write_journal'     => false,//by default, no journaling required before ack
+        'write_concern'     => 1,//by default, MongoClient uses w=1 (Mongo 'safe' mode)
+        'write_journal'     => false,//by default, no journaling required before ack
     );
 
     /**
@@ -189,26 +189,26 @@ class MongoSession
         //we need to ensure that PHP knows about our explicit timeout
         ini_set('session.gc_maxlifetime', $this->getConfig('lifetime'));
 
-	//Mongo/MongoClient( uri, options )
-	$mongo_options = array();
-	foreach($this->getConfig('connection_opts') as $optname=>$optvalue){
-	  $mongo_options[$optname] = $optvalue;
-	}
+        //Mongo/MongoClient( uri, options )
+        $mongo_options = array();
+        foreach($this->getConfig('connection_opts') as $optname=>$optvalue){
+          $mongo_options[$optname] = $optvalue;
+        }
 
-	//Mongo() defunct, use MongoClient() if available
-	$mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
+        //Mongo() defunct, use MongoClient() if available
+        $mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
         $this->conn = new $mongo_class(
-				       $this->getConfig('connection'),
-				       $mongo_options
-				       );
+                                       $this->getConfig('connection'),
+                                       $mongo_options
+                                       );
 
-	if($mongo_class == 'MongoClient'){	  
-	  //set write concern from config
-	  $this->instConfig['write_options'] = array('w'=>$this->getConfig('write_concern'), 'j'=>$this->getConfig('write_journal'));
-	}else {
-	  //defunct 'safe' write, use safe mode if w > 0
-	  $this->instConfig['write_options'] = array('safe'=>( ($this->getConfig('write_concern')>0) ? (true) : (false)));
-	}
+        if($mongo_class == 'MongoClient'){        
+          //set write concern from config
+          $this->instConfig['write_options'] = array('w'=>$this->getConfig('write_concern'), 'j'=>$this->getConfig('write_journal'));
+        }else {
+          //defunct 'safe' write, use safe mode if w > 0
+          $this->instConfig['write_options'] = array('safe'=>( ($this->getConfig('write_concern')>0) ? (true) : (false)));
+        }
 
         //make the connection explicit
         $this->conn->connect();
@@ -242,12 +242,12 @@ class MongoSession
       $mongo_index = ( (phpversion('mongo') >= '1.5.0') ? ('createIndex') : ('ensureIndex') );
       $this->log("maint: {$mongo_index} on ".$this->getConfig('collection')); 
       $this->sessions->$mongo_index(array(
-					  'last_accessed' => 1
-					  ));
+                                          'last_accessed' => 1
+                                          ));
       $this->log("maint: {$mongo_index} on ".$this->getConfig('lockcollection'));
       $this->locks->$mongo_index(array(
-				       'created' => 1
-				       ));
+                                       'created' => 1
+                                       ));
     }
 
     /**
@@ -311,23 +311,23 @@ class MongoSession
                     $lock['mid'] = $mid;
 
                 try {
-		  $res = $this->locks->insert($lock, $this->getConfig('write_options'));
-		} catch (MongoDuplicateKeyException $e){
-		  //duplicate key may occur during lock race
-		  continue;
+                  $res = $this->locks->insert($lock, $this->getConfig('write_options'));
+                } catch (MongoDuplicateKeyException $e){
+                  //duplicate key may occur during lock race
+                  continue;
                 } catch (MongoCursorException $e) {
                   if(in_array($e->getCode(), array(11000,11001,12582))){
-		    //catch duplicate key if no exception thrown
-		    continue;
-		  }elseif(preg_match('/replication timed out/i', $e->getMessage())){
-		    //replication error, to avoid partial write/lockout override write concern and unlock before error
-		    $this->instConfig['write_options'] = ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
+                    //catch duplicate key if no exception thrown
+                    continue;
+                  }elseif(preg_match('/replication timed out/i', $e->getMessage())){
+                    //replication error, to avoid partial write/lockout override write concern and unlock before error
+                    $this->instConfig['write_options'] = ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
                     //force unlock to prevent lockout from partial write
-		    $this->unlock($sid, true);
-		  }  
-		  //log exception and fail lock
-		  $this->log('exception: ' . $e->getMessage());
-		  break 1;
+                    $this->unlock($sid, true);
+                  }  
+                  //log exception and fail lock
+                  $this->log('exception: ' . $e->getMessage());
+                  break 1;
                 }
 
                 $this->lockAcquired = true;
@@ -505,7 +505,7 @@ class MongoSession
         //find all sessions that are older than $timeout
         $olderThan = time() - $timeout;
 
-	//no ack required
+        //no ack required
         $this->sessions->remove(
             array('last_accessed' => array('$lt' => new MongoDate($olderThan))),
             ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) )

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -316,7 +316,7 @@ class MongoSession
 		  //duplicate key may occur during lock race
 		  continue;
                 } catch (MongoCursorException $e) {
-                  if(preg_match('/duplicate key error/i', $e->getMessage())){
+                  if($e->getCode() == 11000){
 		    //catch duplicate key when with <= 1.5.0
 		    continue;
 		  }elseif(preg_match('/replication timed out/i', $e->getMessage())){

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -316,8 +316,8 @@ class MongoSession
 		  //duplicate key may occur during lock race
 		  continue;
                 } catch (MongoCursorException $e) {
-                  if($e->getCode() == 11000){
-		    //catch duplicate key when with <= 1.5.0
+                  if(in_array($e->getCode(), array(11000,11001,12582))){
+		    //catch duplicate key if no exception thrown
 		    continue;
 		  }elseif(preg_match('/replication timed out/i', $e->getMessage())){
 		    //replication error, to avoid partial write/lockout override write concern and unlock before error

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -207,7 +207,7 @@ class MongoSession
           $this->instConfig['write_options'] = array('w'=>$this->getConfig('write_concern'), 'j'=>$this->getConfig('write_journal'));
         }else {
           //defunct 'safe' write, use safe mode if w > 0
-          $this->instConfig['write_options'] = array('safe'=>( ($this->getConfig('write_concern')>0) ? (true) : (false)));
+          $this->instConfig['write_options'] = array('safe'=>$this->getConfig('write_concern')>0);
         }
 
         //make the connection explicit

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -186,9 +186,11 @@ class MongoSession
         //we need to ensure that PHP knows about our explicit timeout
         ini_set('session.gc_maxlifetime', $this->getConfig('lifetime'));
 
-        $this->conn = new Mongo(
-            $this->getConfig('connection')
-        );
+	//Mongo() defunct, use MongoClient() if available
+	$mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
+        $this->conn = new $mongo_class(
+				       $this->getConfig('connection')
+				       );
 
         //make the connection explicit
         $this->conn->connect();

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -47,6 +47,7 @@ class MongoSession
     private static $config = array(
         'name'              => 'PHPSESSID',
         'connection'        => 'mongodb://localhost:27017',
+	'connection_opts'   => array(),//options to pass to MongoClient
         'db'                => 'mySessDb',
         'collection'        => 'sessions',
         'lockcollection'    => 'sessions_lock',
@@ -186,10 +187,17 @@ class MongoSession
         //we need to ensure that PHP knows about our explicit timeout
         ini_set('session.gc_maxlifetime', $this->getConfig('lifetime'));
 
+	//Mongo/MongoClient( uri, options )
+	$mongo_options = array();
+	foreach($this->getConfig('connection_opts') as $optname=>$optvalue){
+	  $mongo_options[$optname] = $optvalue;
+	}
+
 	//Mongo() defunct, use MongoClient() if available
 	$mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
         $this->conn = new $mongo_class(
-				       $this->getConfig('connection')
+				       $this->getConfig('connection'),
+				       $mongo_options
 				       );
 
         //make the connection explicit

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ If you're going to try running session handling on a single MongoDB instance, yo
 asking for trouble. Each application obviously has its own requirements and load so you need to
 analyze this. However, running a replica set with 3 or more machines is a good place to start.
 
+### Acknowledges
+
+By default this class will require acknowledged writes from the primary only. You can configure the 
+write concern as desired using the 'write_concern' configuration option. For example, set 'write_concern'
+to 2 to require acknowledgment from your primary and one secondary.
+
+You must not pass an integer 'write_concern' value as a string or it will be interpreted as a replica tag set.
+
+### Journaling
+
+By default this class does not require journaling before acknowleding the write. You can override this
+behavior and require writes are journaled before ack'd by setting the 'write_journal' boolean. When set
+to true, Mongo will flush the write to disk from memory before acknowledging the write.
+
 Why, oh why?
 ============
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ MongoSession::init();
 
 You can pass `true` to `init(…)` the first time it runs so that you create the indices, but that's it.
 
+You can pass options to MongoClient() via `connection_opts` in config.
+
+Ex, connect to replicaSet and define timeout:
+
+```php
+MongoSession::config(array(
+                           'connection'=>'mongodb://mongo1:27017,mongo2:27017',
+                           'connection_opts'=>array(
+                                                    'replicaSet'=>'rs1',
+                                                    'connecttimeoutMS'=>5000,
+                                                    ),
+                           'cookie_domain'=>'.mydomain.com',
+                           'db'=>'theDbName',
+```
+
 Sessions are hard
 =================
 


### PR DESCRIPTION
I've added logic to use MongoClient() if it's available, and to fallback to Mongo(). Along with that comes the now defunct 'safe' mode being used with Mongo(). Write concern/preferences are now used with MongoClient, and it fallsback to 'safe' mode with Mongo().

New config options:

connection_opts -- array of options to pass down to MongoClient()
write_concern -- same default as MongoClient, 1, can be changed to 2+ to require writes to secondaries
write_journal -- same default as MongoClient, false, can be enabled to require journal before ack

I also updated gc() so it uses w=0 instead of safe=false if using MongoClient.

I replaced ->save with ->insert in lock(), fixing #1. The lock is now using insert. I tested and confirmed the duplicate key exception gets thrown. The catch properly ignores that exception, but also now properly breaks out on any other exception (like write concern timeout).

I fixed a potential lock-out issue when a replication time out occurs. The class now calls unlock() to remove the partial writes (mongodb doesn't do this on it's own).

Updated dbInit() to use createIndex() instead of the defunct ensureIndex() for > '1.5.0'
