### PR TITLE
Added support for apps using namespaces

### DIFF
--- a/MongoSession.php
+++ b/MongoSession.php
@@ -198,13 +198,13 @@ class MongoSession
         }
 
         //Mongo() defunct, use MongoClient() if available
-        $mongo_class = ( (class_exists('\MongoClient')) ? ('\MongoClient') : ('\Mongo') );
+        $mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
         $this->conn = new $mongo_class(
                                        $this->getConfig('connection'),
                                        $mongo_options
                                        );
 
-        if ($mongo_class == '\MongoClient') {
+        if ($mongo_class == 'MongoClient') {
           //set write concern from config
           $this->instConfig['write_options'] = array('w'=>$this->getConfig('write_concern'), 'j'=>$this->getConfig('write_journal'));
         } else {
@@ -323,7 +323,7 @@ class MongoSession
                     continue;
                   } elseif (preg_match('/replication timed out/i', $e->getMessage())) {
                     //replication error, to avoid partial write/lockout override write concern and unlock before error
-                    $this->instConfig['write_options'] = ( (class_exists('\MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
+                    $this->instConfig['write_options'] = ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
                     //force unlock to prevent lockout from partial write
                     $this->unlock($sid, true);
                   }
@@ -510,7 +510,7 @@ class MongoSession
         //no ack required
         $this->sessions->remove(
             array('last_accessed' => array('$lt' => new MongoDate($olderThan))),
-            ( (class_exists('\MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) )
+            ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) )
         );
 
         return true;

--- a/MongoSession.php
+++ b/MongoSession.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @author            Nick Ilyin nick.ilyin@gmail.com
  * @version            v0.1
@@ -180,7 +181,7 @@ class MongoSession
         $this->setConfig(self::$config);
 
         //set the cookie settings
-        session_set_cookie_params(0, $this->getConfig('cookie_path'), $this->getConfig('cookie_domain'),
+        session_set_cookie_params($this->getConfig('timeout'), $this->getConfig('cookie_path'), $this->getConfig('cookie_domain'),
             $this->getConfig('cookie_secure'), $this->getConfig('cookie_httponly'));
 
         //set HTTP cache headers
@@ -188,7 +189,7 @@ class MongoSession
         session_cache_expire($this->getConfig('cache_expiry'));
 
         //we need to ensure that PHP knows about our explicit timeout
-        ini_set('session.gc_maxlifetime', $this->getConfig('lifetime'));
+        ini_set('session.gc_maxlifetime', $this->getConfig('timeout'));
 
         //Mongo/MongoClient( uri, options )
         $mongo_options = array();
@@ -197,13 +198,13 @@ class MongoSession
         }
 
         //Mongo() defunct, use MongoClient() if available
-        $mongo_class = ( (class_exists('MongoClient')) ? ('MongoClient') : ('Mongo') );
+        $mongo_class = ( (class_exists('\MongoClient')) ? ('\MongoClient') : ('\Mongo') );
         $this->conn = new $mongo_class(
                                        $this->getConfig('connection'),
                                        $mongo_options
                                        );
 
-        if ($mongo_class == 'MongoClient') {
+        if ($mongo_class == '\MongoClient') {
           //set write concern from config
           $this->instConfig['write_options'] = array('w'=>$this->getConfig('write_concern'), 'j'=>$this->getConfig('write_journal'));
         } else {
@@ -322,7 +323,7 @@ class MongoSession
                     continue;
                   } elseif (preg_match('/replication timed out/i', $e->getMessage())) {
                     //replication error, to avoid partial write/lockout override write concern and unlock before error
-                    $this->instConfig['write_options'] = ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
+                    $this->instConfig['write_options'] = ( (class_exists('\MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) );
                     //force unlock to prevent lockout from partial write
                     $this->unlock($sid, true);
                   }
@@ -509,7 +510,7 @@ class MongoSession
         //no ack required
         $this->sessions->remove(
             array('last_accessed' => array('$lt' => new MongoDate($olderThan))),
-            ( (class_exists('MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) )
+            ( (class_exists('\MongoClient')) ? (array('w'=>0)) : (array('safe'=>false)) )
         );
 
         return true;


### PR DESCRIPTION
For coherency, I had to place the class into a namespace (not included in this fix of course). 

Prior to the fix, class_exists('MongoClient') would fail, as MongoClient was not in the same namespace, hence the change to class_exists('\MongoClient'). 

Two issues were fixed regarding session timeout:
- cookie was not set
- session.gc_maxlifetime was not set using the right option

Thanks for this awesome class!
